### PR TITLE
Defaults subElements property to array to fix PHP warnings

### DIFF
--- a/src/Url.php
+++ b/src/Url.php
@@ -34,7 +34,7 @@ class Url implements OutputInterface
     /**
      * @var OutputInterface[]
      */
-    protected $subElements;
+    protected $subElements = [];
     /**
      * @var array
      */


### PR DESCRIPTION
This PR addresses a PHP warning that is triggered when an unset var is called as an array.

```
Warning: Invalid argument supplied for foreach() in ../src/Url.php on line 72
````

The warning is triggered on Warning: Invalid argument supplied for foreach() in /Users/jemerick/development/web/vendor/thepixeldeveloper/sitemap/src/Url.php on line 72, when the method `getSubElements()` as called within a foreach loop. If the property `subElements` has not been modified by `addSubElement()`, than this variable is not set and is thus not an array, and will generate the warning.