### PR TITLE
Write any remaining attributes to the urlset element before writing sub-elements

### DIFF
--- a/spec/UrlSpec.php
+++ b/spec/UrlSpec.php
@@ -4,8 +4,6 @@ namespace spec\Thepixeldeveloper\Sitemap;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Thepixeldeveloper\Sitemap\Subelements\Image;
-use XMLWriter;
 
 class UrlSpec extends ObjectBehavior
 {
@@ -37,20 +35,5 @@ class UrlSpec extends ObjectBehavior
     function it_should_have_a_priority()
     {
         $this->getPriority()->shouldReturn(null);
-    }
-
-    function it_should_only_append_attributes_once_for_each_subelement_type(XMLWriter $xmlWriter, Image $image)
-    {
-        $xmlWriter->startElement('url')->shouldBeCalled();
-        $xmlWriter->writeElement('loc', 'http://www.example.com/')->shouldBeCalled();
-        $xmlWriter->endElement()->shouldBeCalled();
-
-        $this->addSubElement($image);
-        $this->addSubElement($image);
-
-        $image->appendAttributeToCollectionXML($xmlWriter)->shouldBeCalled();
-        $image->generateXML($xmlWriter)->shouldBeCalled();
-
-        $this->generateXML($xmlWriter);
     }
 }

--- a/spec/UrlsetSpec.php
+++ b/spec/UrlsetSpec.php
@@ -5,6 +5,9 @@ namespace spec\Thepixeldeveloper\Sitemap;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Thepixeldeveloper\Sitemap\Url;
+use Thepixeldeveloper\Sitemap\Subelements\Image;
+use Thepixeldeveloper\Sitemap\Subelements\Video;
+use XMLWriter;
 
 class UrlsetSpec extends ObjectBehavior
 {
@@ -23,5 +26,27 @@ class UrlsetSpec extends ObjectBehavior
         $this->addUrl($url)->shouldReturn($this);
 
         $this->getUrls()->shouldReturn([$url]);
+    }
+
+    function it_should_only_append_attributes_once_for_each_subelement_type(XMLWriter $xmlWriter, Url $url, Image $image, Video $video)
+    {
+        $xmlWriter->startElement('urlset')->shouldBeCalled();
+        $xmlWriter->writeAttribute('xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance')->shouldBeCalled();
+        $xmlWriter->writeAttribute('xsi:schemaLocation', 'http://www.sitemaps.org/schemas/sitemap/0.9 ' . 'http://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd')->shouldBeCalled();
+        $xmlWriter->writeAttribute('xmlns', 'http://www.sitemaps.org/schemas/sitemap/0.9')->shouldBeCalled();
+
+        $url->getSubelementsThatAppend()->willReturn([$image, $video]);
+        $this->appendSubelementAttribute($xmlWriter, $image)->shouldReturn(true);
+        $this->appendSubelementAttribute($xmlWriter, $image)->shouldReturn(false);
+        $this->appendSubelementAttribute($xmlWriter, $video)->shouldReturn(true);
+        $this->appendSubelementAttribute($xmlWriter, $video)->shouldReturn(false);
+
+        $image->appendAttributeToCollectionXML($xmlWriter)->shouldBeCalled();
+        $video->appendAttributeToCollectionXML($xmlWriter)->shouldBeCalled();
+        $url->generateXML($xmlWriter)->shouldBeCalled();
+        $xmlWriter->endElement()->shouldBeCalled();
+
+        $this->addUrl($url);
+        $this->generateXML($xmlWriter);
     }
 }

--- a/src/Url.php
+++ b/src/Url.php
@@ -68,10 +68,6 @@ class Url implements OutputInterface
      */
     public function generateXML(XMLWriter $XMLWriter)
     {
-        foreach ($this->getSubelementsThatAppend() as $subelement) {
-            $subelement->appendAttributeToCollectionXML($XMLWriter);
-        }
-
         $XMLWriter->startElement('url');
         $XMLWriter->writeElement('loc', $this->getLoc());
 

--- a/src/Urlset.php
+++ b/src/Urlset.php
@@ -56,10 +56,7 @@ class Urlset implements OutputInterface
 
         foreach ($this->getUrls() as $url) {
             foreach ($url->getSubelementsThatAppend() as $subelement) {
-                if (!$this->isSubelementAppended($subelement)) {
-                    $subelement->appendAttributeToCollectionXML($XMLWriter);
-                    $this->appendedSubelements[get_class($subelement)] = $subelement;
-                }
+                $this->appendSubelementAttribute($XMLWriter, $subelement);
             }
         }
 
@@ -81,14 +78,22 @@ class Urlset implements OutputInterface
     }
 
     /**
-     * Checks if the sub-element has been appended to the collection attributes.
+     * Appends the sub-element to the collection attributes if it has yet to be visited.
      *
+     * @param XMLWriter $XMLWriter
      * @param OutputInterface $subelement
      *
      * @return boolean
      */
-    protected function isSubelementAppended(OutputInterface $subelement)
+    public function appendSubelementAttribute(XMLWriter $XMLWriter, OutputInterface $subelement)
     {
-        return array_key_exists(get_class($subelement), $this->appendedSubelements);
+        if (array_key_exists(get_class($subelement), $this->appendedSubelements)) {
+            return false;
+        }
+
+        $subelement->appendAttributeToCollectionXML($XMLWriter);
+        $this->appendedSubelements[get_class($subelement)] = $subelement;
+
+        return true;
     }
 }

--- a/src/Urlset.php
+++ b/src/Urlset.php
@@ -19,6 +19,13 @@ class Urlset implements OutputInterface
     protected $urls = [];
 
     /**
+     * Sub-elements that have been appended to the collection attributes.
+     *
+     * @var AppendAttributeInterface[]
+     */
+    protected $appendedSubelements = [];
+
+    /**
      * Add a new URL object.
      *
      * @param OutputInterface $url
@@ -48,6 +55,15 @@ class Urlset implements OutputInterface
         $XMLWriter->writeAttribute('xmlns', 'http://www.sitemaps.org/schemas/sitemap/0.9');
 
         foreach ($this->getUrls() as $url) {
+            foreach ($url->getSubelementsThatAppend() as $subelement) {
+                if (!$this->isSubelementAppended($subelement)) {
+                    $subelement->appendAttributeToCollectionXML($XMLWriter);
+                    $this->appendedSubelements[get_class($subelement)] = $subelement;
+                }
+            }
+        }
+
+        foreach ($this->getUrls() as $url) {
             $url->generateXML($XMLWriter);
         }
 
@@ -62,5 +78,17 @@ class Urlset implements OutputInterface
     public function getUrls()
     {
         return $this->urls;
+    }
+
+    /**
+     * Checks if the sub-element has been appended to the collection attributes.
+     *
+     * @param OutputInterface $subelement
+     *
+     * @return boolean
+     */
+    protected function isSubelementAppended(OutputInterface $subelement)
+    {
+        return array_key_exists(get_class($subelement), $this->appendedSubelements);
     }
 }


### PR DESCRIPTION
According to the [XMLWriter::writeAttribute user notes](http://php.net/manual/en/function.xmlwriter-write-attribute.php), writing a sub-element prevents any further attributes being added to the root element, which would explain the behaviour I encountered recently in #33.

I've moved the writing of attributes for sub-elements to happen before the first url element is generated, following a logic style similar to that used for checking if a sub-element is going to append. Hope this is OK if anything needs changing just let me know, cheers!