### PR TITLE
Add PHP version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,9 @@
 			"role": "Developer"
 		}
 	],
+	"require": {
+		"php": ">=5.5.0"
+	}
 	"require-dev": {
 		"phpspec/phpspec": "^2.4"
 	},

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 	],
 	"require": {
 		"php": ">=5.5.0"
-	}
+	},
 	"require-dev": {
 		"phpspec/phpspec": "^2.4"
 	},


### PR DESCRIPTION
Since we're using `[]` in the code, we need at least PHP 5.5.* to be installed on the system.