### PR TITLE
Allow $lastMod to be set from DateTime like.

### DIFF
--- a/src/Sitemap.php
+++ b/src/Sitemap.php
@@ -73,13 +73,17 @@ class Sitemap implements OutputInterface
     /**
      * Set the last modification time.
      *
-     * @param string $lastMod
+     * @param string|\DateTimeInterface $lastMod
      *
      * @return $this
      */
     public function setLastMod($lastMod)
     {
-        $this->lastMod = $lastMod;
+        if ($lastMod instanceof \DateTimeInterface) {
+            $this->lastMod = $lastMod->format(\DateTime::W3C);
+        } else {
+            $this->lastMod = $lastMod;
+        }
 
         return $this;
     }

--- a/src/Url.php
+++ b/src/Url.php
@@ -139,13 +139,17 @@ class Url implements OutputInterface
     /**
      * Set last modification time.
      *
-     * @param string $lastMod
+     * @param string|\DateTimeInterface $lastMod
      *
      * @return $this
      */
     public function setLastMod($lastMod)
     {
-        $this->lastMod = $lastMod;
+        if ($lastMod instanceof \DateTimeInterface) {
+            $this->lastMod = $lastMod->format(\DateTime::W3C);
+        } else {
+            $this->lastMod = $lastMod;
+        }
 
         return $this;
     }


### PR DESCRIPTION
Since dates will be most commonly represented as some DateTime object internally, it makes sense that the `$lastMod` property can be set using this. This saves users the trouble of figuring out which formatting constant to use, and allows for cleaner code.

DateTime support has been included in PHP since version 5.2, so this should cause no BC-breaks.