### PR TITLE
Correcting a schema reference

### DIFF
--- a/src/Subelements/Link.php
+++ b/src/Subelements/Link.php
@@ -56,7 +56,7 @@ class Link implements OutputInterface, AppendAttributeInterface
      */
     public function appendAttributeToCollectionXML(XMLWriter $XMLWriter)
     {
-        $XMLWriter->writeAttribute('xmlns:xhtml', 'https://www.w3.org/1999/xhtml');
+        $XMLWriter->writeAttribute('xmlns:xhtml', 'http://www.w3.org/1999/xhtml');
     }
 
     /**


### PR DESCRIPTION
This is not strictly a uri, it is a string referencing a specific schema.

Quite confusingly noted in the docs as a URI reference; https://www.w3.org/TR/xhtml1-schema/