### PR TITLE
#53 - wrong sitemap-image namespace

### DIFF
--- a/spec/OutputSpec.php
+++ b/spec/OutputSpec.php
@@ -43,7 +43,7 @@ XML;
     {
         $xml = <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 https://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="https://www.google.com/schemas/sitemap-image/1.1">
+<urlset xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 https://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
     <url>
         <loc>https://www.example.com/1</loc>
         <image:image>

--- a/src/Subelements/Image.php
+++ b/src/Subelements/Image.php
@@ -197,6 +197,6 @@ class Image implements OutputInterface, AppendAttributeInterface
      */
     public function appendAttributeToCollectionXML(XMLWriter $XMLWriter)
     {
-        $XMLWriter->writeAttribute('xmlns:image', 'https://www.google.com/schemas/sitemap-image/1.1');
+        $XMLWriter->writeAttribute('xmlns:image', 'http://www.google.com/schemas/sitemap-image/1.1');
     }
 }


### PR DESCRIPTION
I got this error on webmaster tools 

Your Sitemap or Sitemap index file doesn't properly declare the namespace. Expected: http://www.google.com/schemas/sitemap-image/1.1 Found: https://www.google.com/schemas/sitemap-image/1.1