### PR TITLE
Bugfix/wrong namespace2

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ $urlSet->add($url);
 $driver = new XmlWriterDriver();
 $urlset->accept($driver);
 
-echo $driver->getOutput();
+echo $driver->output();
 ```
 
 ## Extensions

--- a/src/Drivers/XmlWriterDriver.php
+++ b/src/Drivers/XmlWriterDriver.php
@@ -35,15 +35,15 @@ class XmlWriterDriver implements DriverInterface
     private $extensionAttributes = [
         Video::class  => [
             'name'    => 'xmlns:video',
-            'content' => 'https://www.google.com/schemas/sitemap-video/1.1',
+            'content' => 'http://www.google.com/schemas/sitemap-video/1.1',
         ],
         News::class   => [
             'name'    => 'xmlns:news',
-            'content' => 'https://www.google.com/schemas/sitemap-news/0.9',
+            'content' => 'http://www.google.com/schemas/sitemap-news/0.9',
         ],
         Mobile::class => [
             'name'    => 'xmlns:mobile',
-            'content' => 'https://www.google.com/schemas/sitemap-mobile/1.0',
+            'content' => 'http://www.google.com/schemas/sitemap-mobile/1.0',
         ],
         Link::class => [
             'name'    => 'xmlns:xhtml',
@@ -93,11 +93,11 @@ class XmlWriterDriver implements DriverInterface
     public function visitSitemapIndex(SitemapIndex $sitemapIndex)
     {
         $this->writer->startElement('sitemapindex');
-        $this->writer->writeAttribute('xmlns:xsi', 'https://www.w3.org/2001/XMLSchema-instance');
+        $this->writer->writeAttribute('xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
 
         $this->writer->writeAttribute(
             'xsi:schemaLocation',
-            'http://www.sitemaps.org/schemas/sitemap/0.9 https://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd'
+            'http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd'
         );
 
         foreach ($sitemapIndex->all() as $item) {
@@ -123,12 +123,12 @@ class XmlWriterDriver implements DriverInterface
 
         $this->writer->writeAttribute(
             'xmlns:xsi',
-            'https://www.w3.org/2001/XMLSchema-instance'
+            'http://www.w3.org/2001/XMLSchema-instance'
         );
 
         $this->writer->writeAttribute(
             'xsi:schemaLocation',
-            'http://www.sitemaps.org/schemas/sitemap/0.9 https://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd'
+            'http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd'
         );
 
         $this->writer->writeAttribute(

--- a/tests/CompleteTest.php
+++ b/tests/CompleteTest.php
@@ -38,13 +38,13 @@ class CompleteTest extends TestCase
         $urlset->accept($driver);
 
         $expected = <<<XML
-<urlset xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 https://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd"
+<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd"
         xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
         xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml"
-        xmlns:mobile="https://www.google.com/schemas/sitemap-mobile/1.0"
-        xmlns:news="https://www.google.com/schemas/sitemap-news/0.9"
-        xmlns:video="https://www.google.com/schemas/sitemap-video/1.1">
+        xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0"
+        xmlns:news="http://www.google.com/schemas/sitemap-news/0.9"
+        xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
     <url>
         <loc>http://example.com</loc>
         <image:image>
@@ -91,8 +91,8 @@ XML;
 
         $expected = <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
-<sitemapindex xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
-              xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 https://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd">
+<sitemapindex xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd">
     <sitemap>
         <loc>http://example.com</loc>
     </sitemap>

--- a/tests/Drivers/XmlWriterDriverTest.php
+++ b/tests/Drivers/XmlWriterDriverTest.php
@@ -38,7 +38,7 @@ XML;
 
         $expected = <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
-<sitemapindex xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 https://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd"/>
+<sitemapindex xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd"/>
 XML;
         $this->assertSame($expected, $driver->output());
     }
@@ -70,7 +70,7 @@ XML;
 
         $expected = <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 https://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"/>
+<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"/>
 XML;
         $this->assertSame($expected, $driver->output());
     }


### PR DESCRIPTION
Hi, this PR is to fix wrong namespace (again), see issue #53. 
and i fix a typo on README.md, it should `$driver->output()` and not `$driver->getOutput()`