### PR TITLE
Added xmlns to sitemapindex for compliance with google

### DIFF
--- a/src/Drivers/XmlWriterDriver.php
+++ b/src/Drivers/XmlWriterDriver.php
@@ -100,6 +100,12 @@ class XmlWriterDriver implements DriverInterface
             'http://www.sitemaps.org/schemas/sitemap/0.9 https://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd'
         );
 
+        // google requires this to be declared in the root sitemap element
+        $this->writer->writeAttribute(
+            'xmlns',
+            'http://www.sitemaps.org/schemas/sitemap/0.9'
+        );
+
         foreach ($sitemapIndex->all() as $item) {
             $item->accept($this);
         }

--- a/src/Drivers/XmlWriterDriver.php
+++ b/src/Drivers/XmlWriterDriver.php
@@ -99,8 +99,7 @@ class XmlWriterDriver implements DriverInterface
             'xsi:schemaLocation',
             'http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd'
         );
-
-        // google requires this to be declared in the root sitemap element
+        
         $this->writer->writeAttribute(
             'xmlns',
             'http://www.sitemaps.org/schemas/sitemap/0.9'

--- a/tests/CompleteTest.php
+++ b/tests/CompleteTest.php
@@ -91,7 +91,7 @@ XML;
 
         $expected = <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
-<sitemapindex xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+<sitemapindex xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     <sitemap>
         <loc>http://example.com</loc>

--- a/tests/CompleteTest.php
+++ b/tests/CompleteTest.php
@@ -92,7 +92,7 @@ XML;
         $expected = <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
-              xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 https://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd">
+              xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 https://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     <sitemap>
         <loc>http://example.com</loc>
     </sitemap>

--- a/tests/Drivers/XmlWriterDriverTest.php
+++ b/tests/Drivers/XmlWriterDriverTest.php
@@ -38,7 +38,7 @@ XML;
 
         $expected = <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
-<sitemapindex xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 https://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd"/>
+<sitemapindex xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 https://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"/>
 XML;
         $this->assertSame($expected, $driver->output());
     }


### PR DESCRIPTION
This pull request addresses an issue where google search console says that the sitemapindex file is invalid because it lacks the required namespace declaration