### PR TITLE
fix typo in readme: variable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ $url->setLastMod($lastMod);
 $url->setChangeFreq($changeFreq);
 $url->setPriority($priority);
 
-$urlset = new Urlset();
+$urlSet = new Urlset();
 $urlSet->add($url);
 
 $driver = new XmlWriterDriver();


### PR DESCRIPTION
## Description
Fixed a typo in variable name. I actually had to open my PHPStorm to notice that part when I am copy pasting to test this script.