### PR TITLE
fix: use correct schemaLocation for urlset

### DIFF
--- a/src/Drivers/XmlWriterDriver.php
+++ b/src/Drivers/XmlWriterDriver.php
@@ -138,7 +138,7 @@ class XmlWriterDriver implements DriverInterface
 
         $this->writer->writeAttribute(
             'xsi:schemaLocation',
-            'http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd'
+            'http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd'
         );
 
         $this->writer->writeAttribute(

--- a/tests/CompleteTest.php
+++ b/tests/CompleteTest.php
@@ -39,7 +39,7 @@ class CompleteTest extends TestCase
 
         $expected = <<<XML
 <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd"
+        xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"
         xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
         xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml"
         xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0"

--- a/tests/Drivers/XmlWriterDriverTest.php
+++ b/tests/Drivers/XmlWriterDriverTest.php
@@ -85,7 +85,7 @@ XML;
 
         $expected = <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"/>
+<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"/>
 XML;
         $this->assertSame($expected, $driver->output());
     }


### PR DESCRIPTION
## Description
Currently the sitemap/urlset schema location is wrongly pointing to the [sitemap _index_ schema](https://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd). It should be pointing to the [sitemap schema](https://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd).

Please refer to https://www.sitemaps.org/protocol.html#validating

## Todos

- [x] Tests