### PR TITLE
fix: use correct schemaLocation for urlset (v4 compat)

### DIFF
--- a/spec/OutputSpec.php
+++ b/spec/OutputSpec.php
@@ -43,7 +43,7 @@ XML;
     {
         $xml = <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 https://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
+<urlset xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 https://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
     <url>
         <loc>https://www.example.com/1</loc>
         <image:image>
@@ -101,7 +101,7 @@ XML;
     {
         $xml = <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 https://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+<urlset xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 https://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
     <url>
         <loc>https://www.example.com/english/</loc>
         <xhtml:link rel="alternate" hreflang="de" href="https://www.example.com/deutsch/"/>
@@ -149,7 +149,7 @@ XML;
         $xml = <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet type="text/xsl" href="/path/to/xslt/main-sitemap.xsl"?>
-<urlset xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 https://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+<urlset xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 https://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
     <url>
         <loc>https://www.example.com/english/</loc>
         <xhtml:link rel="alternate" hreflang="de" href="https://www.example.com/deutsch/"/>

--- a/spec/UrlsetSpec.php
+++ b/spec/UrlsetSpec.php
@@ -32,7 +32,7 @@ class UrlsetSpec extends ObjectBehavior
     {
         $xmlWriter->startElement('urlset')->shouldBeCalled();
         $xmlWriter->writeAttribute('xmlns:xsi', 'https://www.w3.org/2001/XMLSchema-instance')->shouldBeCalled();
-        $xmlWriter->writeAttribute('xsi:schemaLocation', 'http://www.sitemaps.org/schemas/sitemap/0.9 ' . 'https://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd')->shouldBeCalled();
+        $xmlWriter->writeAttribute('xsi:schemaLocation', 'http://www.sitemaps.org/schemas/sitemap/0.9 ' . 'https://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd')->shouldBeCalled();
         $xmlWriter->writeAttribute('xmlns', 'http://www.sitemaps.org/schemas/sitemap/0.9')->shouldBeCalled();
 
         $url->getSubelementsThatAppend()->willReturn([$image, $video]);

--- a/src/Urlset.php
+++ b/src/Urlset.php
@@ -50,7 +50,7 @@ class Urlset implements OutputInterface
 
         $XMLWriter->writeAttribute('xsi:schemaLocation',
             'http://www.sitemaps.org/schemas/sitemap/0.9 ' .
-            'https://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd');
+            'https://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd');
 
         $XMLWriter->writeAttribute('xmlns', 'http://www.sitemaps.org/schemas/sitemap/0.9');
 


### PR DESCRIPTION
## Description
@ThePixelDeveloper re PR https://github.com/ThePixelDeveloper/Sitemap/pull/69 - it seems this has been tagged in `4.5.6` but it looks like it should have been tagged as `5.1.4`?

The change in _this_ PR would be the change needed if we wanted to patch `4.*`

I think this may be breaking for anyone on `^4` - is it possible to delete the `4.5.6` tag / make a new one with the changes in this PR?